### PR TITLE
Refactor static site code changed flag

### DIFF
--- a/event-bus.service.ts
+++ b/event-bus.service.ts
@@ -1,0 +1,12 @@
+import { Injectable, EventEmitter } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EventBusService {
+  public siteCodeChanged = new EventEmitter<void>();
+  
+  public emitSiteCodeChanged(): void {
+    this.siteCodeChanged.emit();
+  }
+}

--- a/other-service.ts
+++ b/other-service.ts
@@ -16,8 +16,8 @@ export class YourOtherService {
     const put$ = this.http.put<CRCAuthorizationResult>(`${this.config?.url}/Location/${siteCode}`, null)
       .pipe(
         tap(() => {
-          // Notify about site code change
-          this.siteCodeService.notifySiteCodeChanged();
+          // Update the site code (will only emit if it's different)
+          this.siteCodeService.updateSiteCode(siteCode);
         })
       );
     

--- a/other-service.ts
+++ b/other-service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { SiteCodeService } from './site-code.service';
+
+@Injectable()
+export class YourOtherService {
+  
+  constructor(
+    private http: HttpClient,
+    private siteCodeService: SiteCodeService,
+    private config: YourConfig
+  ) {}
+
+  private put$(siteCode: string): Observable<BaseSite[]> {
+    const put$ = this.http.put<CRCAuthorizationResult>(`${this.config?.url}/Location/${siteCode}`, null)
+      .pipe(
+        tap(() => {
+          // Notify about site code change
+          this.siteCodeService.notifySiteCodeChanged();
+        })
+      );
+    
+    return put$;
+  }
+}

--- a/other-service.ts
+++ b/other-service.ts
@@ -16,8 +16,8 @@ export class YourOtherService {
     const put$ = this.http.put<CRCAuthorizationResult>(`${this.config?.url}/Location/${siteCode}`, null)
       .pipe(
         tap(() => {
-          // Update the site code (will only emit if it's different)
-          this.siteCodeService.updateSiteCode(siteCode);
+          // Notify about site code change (only emits if different)
+          this.siteCodeService.notifySiteCodeChanged(siteCode);
         })
       );
     

--- a/section.component.alternative.ts
+++ b/section.component.alternative.ts
@@ -1,9 +1,10 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { Subject, takeUntil, of, filter } from 'rxjs';
+import { Subject, takeUntil, of, finalize } from 'rxjs';
 import { SiteCodeService } from './site-code.service';
 
 export class SectionComponent implements OnInit, OnDestroy {
   private destroy$ = new Subject<void>();
+  private isLoading = false;
 
   constructor(
     private siteCodeService: SiteCodeService,
@@ -12,24 +13,31 @@ export class SectionComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    // Subscribe to site code changes - only when site code is not null
     this.siteCodeService.siteCode$
       .pipe(
-        filter(siteCode => siteCode !== null), // Only proceed if site code exists
+        filter(siteCode => siteCode !== null),
         takeUntil(this.destroy$)
       )
       .subscribe((siteCode) => {
-        this.loadSections();
+        // Prevent multiple simultaneous API calls
+        if (!this.isLoading) {
+          this.loadSections();
+        }
       });
   }
 
   private loadSections(): void {
+    if (this.isLoading) return; // Guard against multiple calls
+    
+    this.isLoading = true;
     const { page } = this.route.snapshot.data;
     
     this.crcApiService.sections$(
       page.pageType,
       this.route.snapshot.paramMap.get('productId') ?? undefined,
       true
+    ).pipe(
+      finalize(() => this.isLoading = false) // Reset loading state
     ).subscribe(sections => {
       this.sections$ = of(sections);
     });

--- a/section.component.ts
+++ b/section.component.ts
@@ -1,0 +1,35 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subject, takeUntil, of } from 'rxjs';
+import { SiteCodeService } from './site-code.service';
+
+export class SectionComponent implements OnInit, OnDestroy {
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private siteCodeService: SiteCodeService,
+    private crcApiService: CrcApiService,
+    private route: ActivatedRoute
+  ) {}
+
+  ngOnInit(): void {
+    // Subscribe to site code changes
+    this.siteCodeService.siteCodeChanged$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        const { page } = this.route.snapshot.data;
+        
+        this.crcApiService.sections$(
+          page.pageType,
+          this.route.snapshot.paramMap.get('productId') ?? undefined,
+          true
+        ).subscribe(sections => {
+          this.sections$ = of(sections);
+        });
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/section.component.ts
+++ b/section.component.ts
@@ -1,9 +1,10 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { Subject, takeUntil, of, filter } from 'rxjs';
+import { Subject, takeUntil, of } from 'rxjs';
 import { SiteCodeService } from './site-code.service';
 
 export class SectionComponent implements OnInit, OnDestroy {
   private destroy$ = new Subject<void>();
+  private isLoadingSections = false;
 
   constructor(
     private siteCodeService: SiteCodeService,
@@ -12,26 +13,36 @@ export class SectionComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    // Subscribe to site code changes - only when site code is not null
-    this.siteCodeService.siteCode$
-      .pipe(
-        filter(siteCode => siteCode !== null), // Only proceed if site code exists
-        takeUntil(this.destroy$)
-      )
-      .subscribe((siteCode) => {
+    // Subscribe to site code changes
+    this.siteCodeService.siteCodeChanged$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
         this.loadSections();
       });
   }
 
   private loadSections(): void {
+    // Prevent multiple simultaneous calls
+    if (this.isLoadingSections) {
+      return;
+    }
+    
+    this.isLoadingSections = true;
     const { page } = this.route.snapshot.data;
     
     this.crcApiService.sections$(
       page.pageType,
       this.route.snapshot.paramMap.get('productId') ?? undefined,
       true
-    ).subscribe(sections => {
-      this.sections$ = of(sections);
+    ).subscribe({
+      next: (sections) => {
+        this.sections$ = of(sections);
+        this.isLoadingSections = false;
+      },
+      error: (error) => {
+        console.error('Error loading sections:', error);
+        this.isLoadingSections = false;
+      }
     });
   }
 

--- a/site-code.actions.ts
+++ b/site-code.actions.ts
@@ -1,0 +1,5 @@
+import { createAction } from '@ngrx/store';
+
+export const siteCodeChanged = createAction(
+  '[Site Code] Site Code Changed'
+);


### PR DESCRIPTION
Replace static `siteCodeChanged` variable with an RxJS Subject service for inter-component communication.

The previous use of a static variable introduced tight coupling and made the code harder to test. This change implements a dedicated service utilizing an RxJS Subject to provide a more robust, decoupled, and Angular-idiomatic way to communicate site code changes across components.

---
<a href="https://cursor.com/background-agent?bcId=bc-e15dd40a-640b-4323-a12b-336c88e06363">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e15dd40a-640b-4323-a12b-336c88e06363">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>