### PR TITLE
Fix clock skew with Auth0

### DIFF
--- a/Source/Projects/MainAPI/Startup.cs
+++ b/Source/Projects/MainAPI/Startup.cs
@@ -1,4 +1,4 @@
-﻿using Autofac;
+using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -9,6 +9,8 @@ using System;
 using DFO.MainAPI.Infrastructure.Filters;
 using Microsoft.AspNetCore.Http;
 using DFO.MainAPI.Extensions;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
 
 namespace DFO.MainAPI
 {
@@ -28,6 +30,33 @@ namespace DFO.MainAPI
             RegisterAppInsights(services);
 
             services.AddMemoryCache();
+
+            // Add JWT Bearer authentication with clock skew tolerance
+            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddJwtBearer(options =>
+                {
+                    // Auth0 domain (should be something like https://your-domain.auth0.com/)
+                    var domain = Configuration["Auth0:Domain"];
+                    
+                    options.Authority = domain;
+                    options.Audience = Configuration["Auth0:Audience"];
+                    
+                    // Configure JWT validation parameters
+                    options.TokenValidationParameters = new TokenValidationParameters
+                    {
+                        ValidateIssuer = true,
+                        ValidateAudience = true,
+                        ValidateLifetime = true,
+                        ValidateIssuerSigningKey = true,
+                        
+                        // Set clock skew tolerance to 5 minutes to handle time synchronization issues
+                        // This is the key setting to fix the Auth0 clock skew error
+                        ClockSkew = TimeSpan.FromMinutes(5),
+                        
+                        ValidIssuer = domain,
+                        ValidAudience = Configuration["Auth0:Audience"]
+                    };
+                });
 
             services.AddMvc(options =>
             {
@@ -89,6 +118,10 @@ namespace DFO.MainAPI
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
 
             app.UseCors("CorsPolicy");
+
+            // Add authentication middleware
+            app.UseAuthentication();
+            app.UseAuthorization();
 
             app.UseMvcWithDefaultRoute();
 

--- a/Source/Projects/MainAPI/appsettings.json
+++ b/Source/Projects/MainAPI/appsettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "UseCustomizationData": false,
   "Logging": {
     "IncludeScopes": false,
@@ -7,5 +7,9 @@
       "System": "Information",
       "Microsoft": "Information"
     }
+  },
+  "Auth0": {
+    "Domain": "https://your-auth0-domain.auth0.com/",
+    "Audience": "your-audience-identifier"
   }
 }


### PR DESCRIPTION
Add JWT Bearer authentication with 5-minute clock skew tolerance to fix Auth0 time synchronization errors.

This addresses the "Clock skew detected" error by allowing a configurable time difference between the local system and Auth0 servers, which is a common issue in containerized environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f811fc5-d147-47b3-815b-a0d37df3eec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f811fc5-d147-47b3-815b-a0d37df3eec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>